### PR TITLE
Fixed error where S&T are set falsely (to E1 and E2 instead) for E6POS.

### DIFF
--- a/JOpenShowVar-core/src/no/hials/crosscom/KRL/structs/KRLPos.java
+++ b/JOpenShowVar-core/src/no/hials/crosscom/KRL/structs/KRLPos.java
@@ -64,7 +64,7 @@ public class KRLPos extends KRLFrame {
      * @param d the value to set
      */
     public void setS(double d) {
-        struct.put(getNodes()[6], d);
+        struct.put("S", d);
     }
 
     /**
@@ -73,6 +73,6 @@ public class KRLPos extends KRLFrame {
      * @param d the value to set
      */
     public void setT(double d) {
-        struct.put(getNodes()[7], d);
+        struct.put("T", d);
     }
 }


### PR DESCRIPTION
This bug happens because the super class of KRLE6Pos, which is KRLPos, uses
the getNodes() array and takes the seventh and eighth element of that list EVERY TIME cause it assumes that S and T are stored there. But for E6POS there are the E1-6 elements which start at nodes[6] and go through nodes[11]. For E6POS objects the S and T are therefore at the nodes[12] and nodes[13] position.

Fixed that bug by specifying the wanted key directly instead of the relativity that getNodes() creates.